### PR TITLE
dealing with deleted wikidata item

### DIFF
--- a/wptools/core.py
+++ b/wptools/core.py
@@ -137,9 +137,17 @@ class WPTools(object):
         if action == 'parse' and not data.get('parse'):
             raise LookupError(_query)
 
-        if action == 'wikidata' and '-1' in data.get('entities'):
-            raise LookupError(_query)
-
+        if action == 'wikidata':
+            entities = data.get('entities')
+            if not entities:
+                raise LookupError(_query)
+            elif '-1' in entities:
+                raise LookupError(_query)
+            else:
+                item = entities.values()[0]
+                if 'missing' in item:
+                    errmsg = "wikidata item %s has been deleted" % item['id']
+                    raise LookupError(errmsg)
         return data
 
     def _query(self, action, qobj):

--- a/wptools/core.py
+++ b/wptools/core.py
@@ -144,7 +144,7 @@ class WPTools(object):
             elif '-1' in entities:
                 raise LookupError(_query)
             else:
-                item = entities.values()[0]
+                item = list(entities.values())[0]
                 if 'missing' in item:
                     errmsg = "wikidata item %s has been deleted" % item['id']
                     raise LookupError(errmsg)


### PR DESCRIPTION
Hi @siznax ,

I found this case when dealing wikidata [deleted item](https://www.wikidata.org/wiki/Q10908976) ,  right now it will raise error when marsal the claims of the item while there is no one..

```
  File "/var/dae/apps/fm/venv/src/wptools/wptools/wikidata.py", line 327, in get_wikidata
    self._get('wikidata', show, proxy, timeout)
  File "/var/dae/apps/fm/venv/src/wptools/wptools/core.py", line 105, in _get
    self._set_data(action)
  File "/var/dae/apps/fm/venv/src/wptools/wptools/page.py", line 171, in _set_data
    self._set_wikidata()
  File "/fm/venv/src/wptools/wptools/wikidata.py", line 187, in _set_wikidata
    self._marshal_claims(item.get('claims'))
  File "/venv/src/wptools/wptools/wikidata.py", line 67, in _marshal_claims
    claims = reduce_claims(query_claims)
  File "/venv/src/wptools/wptools/wikidata.py", line 358, in reduce_claims
    for claim in query_claims:
TypeError: 'NoneType' object is not iterable
```

To reproduce the error, try:

```
import wptools
p = wptools.page(wikibase='Q10908976', lang='en')
p.get_wikidata()
```

The response  data is `{u'entities': {u'Q10908976': {u'id': u'Q10908976', u'missing': u''}}, u'success': 1}`, which I add a simple patch to checking the `missing` key... seems to work but not sure it's the best way of dealing this,  (could this query also be fetching multiple entities, for that case, `_marshal_claims` will still fail for later deleted item)



