### PR TITLE
Prevent error when wikidata has a claim with a no value snak

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -29,6 +29,7 @@ from . import sitematrix
 from . import siteviews
 from . import wikidata
 from . import wikidata_deleted
+from . import wikidata_novalue_snak
 
 SILENT_FLAG = True
 SKIP_FLAG = ['imageinfo', 'labels']
@@ -997,6 +998,12 @@ class WPToolsWikidataTestCase(unittest.TestCase):
             pass
 
         self.assertTrue('requests' not in page.data)
+
+    def test_wikidata_no_value_snak(self):
+        page = wptools.wikidata(skip=SKIP_FLAG, silent=SILENT_FLAG)
+        page.cache = {'wikidata': wikidata_novalue_snak.cache}
+        page._set_data('wikidata')
+        self.assertEqual(len(page.data['claims']), 1)
 
 
 class WPToolsToolTestCase(unittest.TestCase):

--- a/tests/wikidata_novalue_snak.py
+++ b/tests/wikidata_novalue_snak.py
@@ -1,0 +1,65 @@
+# -*- coding:utf-8 -*-
+
+query = 'https://www.wikidata.org/w/api.php?action=wbgetentities&format=json&formatversion=2&ids=Q483718&languages=en&props=info|claims|descriptions|labels|sitelinks&redirects=yes&sites=&titles='
+
+response = r"""{
+    "entities": {
+        "Q483718": {
+            "pageid": 455294,
+            "ns": 0,
+            "title": "Q483718",
+            "lastrevid": 610328494,
+            "modified": "2017-12-17T18:21:13Z",
+            "type": "item",
+            "id": "Q483718",
+            "labels": {
+                "en": {
+                    "language": "en",
+                    "value": "Foo Fighters"
+                }
+            },
+            "descriptions": {
+                "en": {
+                    "language": "en",
+                    "value": "American rock band, formed in Seattle in 1994"
+                }
+            },
+            "claims": {
+                "P576": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "novalue",
+                            "property": "P576",
+                            "hash": "6a18d40010201ff9031e85a3fe98f1f0dc1d7cc4",
+                            "datatype": "time"
+                        },
+                        "type": "statement",
+                        "id": "Q483718$9da5583a-45e8-4268-2770-41d999bd53da",
+                        "rank": "normal"
+                    }
+                ],
+                "P373": [
+                    {
+                        "mainsnak": {
+                            "snaktype": "value",
+                            "property": "P373",
+                            "hash": "4d08e8ef6597a712d926b71c1c3b52d51d99a1a9",
+                            "datavalue": {
+                                "value": "Foo Fighters",
+                                "type": "string"
+                            },
+                            "datatype": "string"
+                        },
+                        "type": "statement",
+                        "id": "q483718$6CA37AA3-178A-41CF-B219-46F9BA68CC03",
+                        "rank": "normal"
+                    }
+                ]
+            },
+            "sitelinks": {}
+        }
+    },
+    "success": 1
+}"""
+
+cache = {'query': query, 'response': response}

--- a/wptools/wikidata.py
+++ b/wptools/wikidata.py
@@ -355,14 +355,14 @@ def reduce_claims(query_claims):
     """
     claims = collections.defaultdict(list)
 
-    for claim in query_claims:
+    for claim, entities in query_claims.items():
 
-        for ent in query_claims.get(claim):
+        for ent in entities:
 
             try:
                 snak = ent.get('mainsnak').get('datavalue').get('value')
             except AttributeError:
-                claims[claim] = []
+                continue
 
             try:
                 if snak.get('id'):


### PR DESCRIPTION
When a wikidata page had a claim with with snaktype = "novalue" the
`reduce_claims` function would not set the `snak` variable, triggering an
`UnboundLocalError` exception. For example:

```
>>> import wptools
>>> wptools.page('Foo Fighters').get_wikidata()
www.wikidata.org (wikidata) Foo Fighters
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/robbie/Developer/Source/wptools/wptools/wikidata.py", line 327, in get_wikidata
    self._get('wikidata', show, proxy, timeout)
  File "/Users/robbie/Developer/Source/wptools/wptools/core.py", line 105, in _get
    self._set_data(action)
  File "/Users/robbie/Developer/Source/wptools/wptools/page.py", line 171, in _set_data
    self._set_wikidata()
  File "/Users/robbie/Developer/Source/wptools/wptools/wikidata.py", line 187, in _set_wikidata
    self._marshal_claims(item.get('claims'))
  File "/Users/robbie/Developer/Source/wptools/wptools/wikidata.py", line 67, in _marshal_claims
    claims = reduce_claims(query_claims)
  File "/Users/robbie/Developer/Source/wptools/wptools/wikidata.py", line 368, in reduce_claims
    if snak.get('id'):
UnboundLocalError: local variable 'snak' referenced before assignment
```

(The "novalue" snak is under the "dissolved, abolished or demolished" claim in the [Foo Fighters data](https://www.wikidata.org/wiki/Q483718).)

This change prevents this by skipping to the next snak when a novalue snak is encountered.

I initially tried adding an empty list to the `claims` dictionary for the claim with the novalue snak. This results in an error in `WPToolsWikidata._update_wikidata()` because the `ilabel` variable is never set but is referenced on [line 248](https://github.com/siznax/wptools/blob/a093684b8732104acc6bbf475ec373be62504971/wptools/wikidata.py#L248).

So in the end I just made the `reduce_claims` function skip over snaks with no value.