### PR TITLE
Fixed use with Chinese characters

### DIFF
--- a/wptools/core.py
+++ b/wptools/core.py
@@ -8,6 +8,7 @@ Support for accessing Wikimedia foundation APIs.
 """
 
 from time import sleep
+import urllib.parse
 
 from wptools.query import WPToolsQuery
 
@@ -113,7 +114,7 @@ class WPTools(object):
 
         params = []
         for item in self.data['continue']:
-            params.append("&%s=%s" % (item, self.data['continue'][item]))
+            params.append("&%s=%s" % (item, urllib.parse.quote_plus(self.data['continue'][item])))
 
         return ''.join(params)
 


### PR DESCRIPTION
When using specific characters, for example Chinese, incorrect url-encoding occurred and a curl-request to an incorrect url was executed. The problem was solved by pre-url-encoding the parameters.

#162