### PR TITLE
Add encoding specification to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,9 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as f:
+with open('README.rst', encoding='utf8') as f:
     readme = f.read()
-with open('HISTORY.rst') as f:
+with open('HISTORY.rst', encoding='utf8') as f:
     history = f.read()
 
 


### PR DESCRIPTION
Need to explicitly state encoding as utf8 for windows users in setup.py otherwise it fails to install. Most likely because of the ✨🦄✨ in the README haha

See here: https://www.python.org/dev/peps/pep-0597/#using-the-default-encoding-is-a-common-mistake