### PR TITLE
Wikidata assumption leads to bad data

### DIFF
--- a/wptools/page.py
+++ b/wptools/page.py
@@ -504,12 +504,14 @@ class WPToolsPage(WPToolsRESTBase,
             self.flags['defer_imageinfo'] = True
 
             self.get_wikidata(False, proxy, timeout)
-            self.get_query(False, proxy, timeout)
-            self.get_parse(False, proxy, timeout)
+            if self.params.get('title'):
+                self.get_query(False, proxy, timeout)
+                self.get_parse(False, proxy, timeout)
 
             self.flags['defer_imageinfo'] = False
 
-            self.get_restbase('/page/summary/', False, proxy, timeout)
+            if self.params.get('title'):
+                self.get_restbase('/page/summary/', False, proxy, timeout)
 
             if show and not self.flags.get('silent'):
                 self.show()

--- a/wptools/wikidata.py
+++ b/wptools/wikidata.py
@@ -138,7 +138,7 @@ class WPToolsWikidata(core.WPTools):
         """
         title = None
         lang = self.params['lang']
-        label = self.data['label']
+        # label = self.data['label']
 
         if item.get('sitelinks'):
             for link in item['sitelinks']:
@@ -146,11 +146,14 @@ class WPToolsWikidata(core.WPTools):
                     title = item['sitelinks'][link]['title']
                     self.data['title'] = title.replace(' ', '_')
 
-        if not self.data.get('title') and label:
-            self.data['title'] = label.replace(' ', '_')
+        # aw - this leads to completely incorrect data because
+        #      it assumes that everything is in en.wikipedia later
+        #
+        # if not self.data.get('title') and label:
+        #     self.data['title'] = label.replace(' ', '_')
 
-        if self.data.get('title') and not self.params.get('title'):
-            self.params['title'] = self.data['title']
+        # if self.data.get('title') and not self.params.get('title'):
+        #     self.params['title'] = self.data['title']
 
     def _set_wikidata(self):
         """


### PR DESCRIPTION
There is an assumption that if there is no matching wikipedia link that label is safe to use when querying wikidata.  It is not.

[Human Tetris](https://www.wikidata.org/wiki/Q60845849).  It is only (currently) available on de and nl wikipedia.  But it takes the 'Human Tetris' label, applies it to en.wikipedia, and ends up pulling the info for Human Tetris which redirects to [Brain Wall](https://en.wikipedia.org/wiki/Brain_Wall).  Completely wrong which corrupts any data being read, for example, the text extract.

With this change, if there is no matching language match when using wikidata:

a) Title is not set
b) Queries that depend upon the title do not happen
